### PR TITLE
clone-content-flag

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -26,3 +26,4 @@ jobs:
         git_user_email: "test@example.com"
         git_commit_message: "This is an automated commit message from GitHub Actions."
         delete_old_environments: true
+        clone_content: true

--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
             cd ${SITE_ROOT}
           fi
 
-          terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes   --message="${PANTHEON_COMMIT_MESSAGE}" ${PANTHEON_CLONE_CONTENT_FLAG}
+          terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes --message="${PANTHEON_COMMIT_MESSAGE}" ${PANTHEON_CLONE_CONTENT_FLAG}
 
       - name: Update deployment status
         uses: bobheadxi/deployments@v1

--- a/action.yml
+++ b/action.yml
@@ -168,7 +168,9 @@ runs:
 
 
           if [ -n "$PANTHEON_CLONE_CONTENT_BOOLEAN" ]; then
+
             export PANTHEON_CLONE_CONTENT_FLAG="--clone-content"
+            echo "{$PANTHEON_CLONE_CONTENT_BOOLEAN}"
             echo "yes, clone content"
           else
             export PANTHEON_CLONE_CONTENT_FLAG=""

--- a/action.yml
+++ b/action.yml
@@ -157,25 +157,25 @@ runs:
           # the default in build tools is 180. But that's regularly failing
           # on a small personal site.
           TERMINUS_BUILD_TOOLS_WORKFLOW_TIMEOUT: 300
-          PANTHEON_CLONE_CONTENT_BOOLEAN: ${{ inputs.clone_content }}
-        run: |
-          #!/bin/bash
-          set +e
+            PANTHEON_CLONE_CONTENT_BOOLEAN: ${{ inputs.clone_content }}
+          run: |
+            #!/bin/bash
+            set +e
+
+            if [ "$PANTHEON_CLONE_CONTENT_BOOLEAN" == "true" ]; then
+              export PANTHEON_CLONE_CONTENT_FLAG="--clone-content"
+              echo "yes, clone content"
+            else
+              export PANTHEON_CLONE_CONTENT_FLAG=""
+              echo "No, do not re clone content"
+            fi
+
+            echo "${PANTHEON_CLONE_CONTENT_BOOLEAN}"
 
           if [ -n "$SITE_ROOT" ]; then
             cd ${SITE_ROOT}
           fi
 
-
-          if [ -n "$PANTHEON_CLONE_CONTENT_BOOLEAN" ]; then
-
-            export PANTHEON_CLONE_CONTENT_FLAG="--clone-content"
-            echo "{$PANTHEON_CLONE_CONTENT_BOOLEAN}"
-            echo "yes, clone content"
-          else
-            export PANTHEON_CLONE_CONTENT_FLAG=""
-            echo "No, do not re clone content"
-          fi
 
           terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes --message="${PANTHEON_COMMIT_MESSAGE}"
 

--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
             cd ${SITE_ROOT}
           fi
 
-          terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes --clone-content   --message="${PANTHEON_COMMIT_MESSAGE}"
+          terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes   --message="${PANTHEON_COMMIT_MESSAGE}"
 
       - name: Update deployment status
         uses: bobheadxi/deployments@v1

--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
             cd ${SITE_ROOT}
           fi
 
-          terminus -n build:env:create --clone-content ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes   --message="${PANTHEON_COMMIT_MESSAGE}"
+          terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes   --message="${PANTHEON_COMMIT_MESSAGE}" --clone-content
 
       - name: Update deployment status
         uses: bobheadxi/deployments@v1

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,6 @@ runs:
 
       - name: Set clone content flag
         shell: bash
-        id: clone content flag
         env:
           CLONE_CONTENT: ${{ inputs.clone_content }}
         run: |
@@ -184,7 +183,7 @@ runs:
             cd ${SITE_ROOT}
           fi
 
-          terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes --message="${PANTHEON_COMMIT_MESSAGE}"
+          terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes ${PANTHEON_CLONE_CONTENT_FLAG} --message="${PANTHEON_COMMIT_MESSAGE}"
 
       - name: Update deployment status
         uses: bobheadxi/deployments@v1

--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
             cd ${SITE_ROOT}
           fi
 
-          terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes ${PANTHEON_CLONE_CONTENT_FLAG} --message="${PANTHEON_COMMIT_MESSAGE}"
+          terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes --clone-content   --message="${PANTHEON_COMMIT_MESSAGE}"
 
       - name: Update deployment status
         uses: bobheadxi/deployments@v1
@@ -197,6 +197,10 @@ runs:
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           env: ${{ env.PANTHEON_TARGET_ENV }}-${{ inputs.pantheon_site }}
           env_url: https://${{ env.PANTHEON_TARGET_ENV }}-${{ inputs.pantheon_site }}.pantheonsite.io
+
+
+
+
 
       - name: Deleting old multidevs
         if: ${{ inputs.delete_old_environments == 'true' && steps.deploy_to_pantheon.outcome == 'success' }}

--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
             cd ${SITE_ROOT}
           fi
 
-          terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes   --message="${PANTHEON_COMMIT_MESSAGE}" --clone-content
+          terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes   --message="${PANTHEON_COMMIT_MESSAGE}" ${PANTHEON_CLONE_CONTENT_FLAG}
 
       - name: Update deployment status
         uses: bobheadxi/deployments@v1

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,12 @@ inputs:
     required: false
     default: "live"
 
+  clone_content:
+    description: "If set to true, the database and files directory will be re-cloned from the source environment. When set to false, this data is only copied upon Multidev creations. Setting this variable to true ensures fresh content but adds time to the build process that can be prohibitive for sites with large databases."
+    required: false
+    default: false
+    type: boolean
+
   delete_old_environments:
     description: "If set to true, Multidev environments associated with closed pull requests will be deleted after deployment completes. It is recommended to set this parameter to true for workflows that run after merges to the main branch."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,27 @@ runs:
 
           echo "PANTHEON_TARGET_ENV=${TARGET_ENV}" >> $GITHUB_ENV
 
+      - name: Set clone content flag
+        shell: bash
+        id: clone content flag
+        env:
+          CLONE_CONTENT: ${{ inputs.clone_content }}
+        run: |
+          #!/bin/bash
+          set +e
+
+          if [ "$CLONE_CONTENT" == "true" ]; then
+            export CLONE_CONTENT_FLAG="--clone-content"
+            echo "Content will be cloned again if the target environment already exists"
+          else
+            export CLONE_CONTENT_FLAG=""
+            echo "Content will NOT be cloned again if the target environment already exists"
+          fi
+
+
+          echo "PANTHEON_CLONE_CONTENT_FLAG=${CLONE_CONTENT_FLAG}" >> $GITHUB_ENV
+
+
 
       - name: start deployment
         uses: bobheadxi/deployments@v1
@@ -103,7 +124,6 @@ runs:
       # todo, make checkout conditional.
       # Consumers might have checked out before calling this
       # composite action.
-      # todo, switch to v4
       - uses: actions/checkout@v4
 
       - name: Install Terminus
@@ -157,20 +177,11 @@ runs:
           # the default in build tools is 180. But that's regularly failing
           # on a small personal site.
           TERMINUS_BUILD_TOOLS_WORKFLOW_TIMEOUT: 300
-          PANTHEON_CLONE_CONTENT_BOOLEAN: ${{ inputs.clone_content }}
         run: |
           #!/bin/bash
           set +e
 
-          if [ "$PANTHEON_CLONE_CONTENT_BOOLEAN" == "true" ]; then
-            export PANTHEON_CLONE_CONTENT_FLAG="--clone-content"
-            echo "yes, clone content"
-          else
-            export PANTHEON_CLONE_CONTENT_FLAG=""
-            echo "No, do not re clone content"
-          fi
-
-          echo "${PANTHEON_CLONE_CONTENT_BOOLEAN}"
+          echo ${PANTHEON_CLONE_CONTENT_FLAG}
 
           if [ -n "$SITE_ROOT" ]; then
             cd ${SITE_ROOT}

--- a/action.yml
+++ b/action.yml
@@ -175,8 +175,6 @@ runs:
           #!/bin/bash
           set +e
 
-          echo ${PANTHEON_CLONE_CONTENT_FLAG}
-
           if [ -n "$SITE_ROOT" ]; then
             cd ${SITE_ROOT}
           fi

--- a/action.yml
+++ b/action.yml
@@ -103,10 +103,7 @@ runs:
             echo "Content will NOT be cloned again if the target environment already exists"
           fi
 
-
           echo "PANTHEON_CLONE_CONTENT_FLAG=${CLONE_CONTENT_FLAG}" >> $GITHUB_ENV
-
-
 
       - name: start deployment
         uses: bobheadxi/deployments@v1

--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
             cd ${SITE_ROOT}
           fi
 
-          terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes   --message="${PANTHEON_COMMIT_MESSAGE}"
+          terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes  --clone-content=true   --message="${PANTHEON_COMMIT_MESSAGE}"
 
       - name: Update deployment status
         uses: bobheadxi/deployments@v1

--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
             cd ${SITE_ROOT}
           fi
 
-          terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes  --clone-content=true   --message="${PANTHEON_COMMIT_MESSAGE}"
+          terminus -n build:env:create --clone-content ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes   --message="${PANTHEON_COMMIT_MESSAGE}"
 
       - name: Update deployment status
         uses: bobheadxi/deployments@v1

--- a/action.yml
+++ b/action.yml
@@ -157,7 +157,7 @@ runs:
           # the default in build tools is 180. But that's regularly failing
           # on a small personal site.
           TERMINUS_BUILD_TOOLS_WORKFLOW_TIMEOUT: 300
-            PANTHEON_CLONE_CONTENT_BOOLEAN: ${{ inputs.clone_content }}
+          PANTHEON_CLONE_CONTENT_BOOLEAN: ${{ inputs.clone_content }}
           run: |
             #!/bin/bash
             set +e

--- a/action.yml
+++ b/action.yml
@@ -157,12 +157,22 @@ runs:
           # the default in build tools is 180. But that's regularly failing
           # on a small personal site.
           TERMINUS_BUILD_TOOLS_WORKFLOW_TIMEOUT: 300
+          PANTHEON_CLONE_CONTENT_BOOLEAN: ${{ inputs.clone_content }}
         run: |
           #!/bin/bash
           set +e
 
           if [ -n "$SITE_ROOT" ]; then
             cd ${SITE_ROOT}
+          fi
+
+
+          if [ -n "$PANTHEON_CLONE_CONTENT_BOOLEAN" ]; then
+            export PANTHEON_CLONE_CONTENT_FLAG="--clone-content"
+            echo "yes, clone content"
+          else
+            export PANTHEON_CLONE_CONTENT_FLAG=""
+            echo "No, do not re clone content"
           fi
 
           terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes --message="${PANTHEON_COMMIT_MESSAGE}"

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,6 @@ inputs:
     description: 'The machine name of your Pantheon site'
     required: true
 
-  # todo add clone-content as argument
-
   target_env:
     description: 'The Pantheon environment to which the deployment will be made. If left blank, the value used will be automatically derrived. Pull requests will deploy to environments named "pr-[NUMBER]" and main/master branch commits will deploy to the Pantheon "dev" environment'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -158,24 +158,23 @@ runs:
           # on a small personal site.
           TERMINUS_BUILD_TOOLS_WORKFLOW_TIMEOUT: 300
           PANTHEON_CLONE_CONTENT_BOOLEAN: ${{ inputs.clone_content }}
-          run: |
-            #!/bin/bash
-            set +e
+        run: |
+          #!/bin/bash
+          set +e
 
-            if [ "$PANTHEON_CLONE_CONTENT_BOOLEAN" == "true" ]; then
-              export PANTHEON_CLONE_CONTENT_FLAG="--clone-content"
-              echo "yes, clone content"
-            else
-              export PANTHEON_CLONE_CONTENT_FLAG=""
-              echo "No, do not re clone content"
-            fi
+          if [ "$PANTHEON_CLONE_CONTENT_BOOLEAN" == "true" ]; then
+            export PANTHEON_CLONE_CONTENT_FLAG="--clone-content"
+            echo "yes, clone content"
+          else
+            export PANTHEON_CLONE_CONTENT_FLAG=""
+            echo "No, do not re clone content"
+          fi
 
-            echo "${PANTHEON_CLONE_CONTENT_BOOLEAN}"
+          echo "${PANTHEON_CLONE_CONTENT_BOOLEAN}"
 
           if [ -n "$SITE_ROOT" ]; then
             cd ${SITE_ROOT}
           fi
-
 
           terminus -n build:env:create ${PANTHEON_SITE}.${PANTHEON_SOURCE_ENV} ${PANTHEON_TARGET_ENV} --yes --message="${PANTHEON_COMMIT_MESSAGE}"
 

--- a/terminus-build-tools-plugin/src/Commands/EnvCreateCommand.php
+++ b/terminus-build-tools-plugin/src/Commands/EnvCreateCommand.php
@@ -74,6 +74,8 @@ class EnvCreateCommand extends BuildToolsBase
         // instead -- but only if requested. No point in running 'clone'
         // if the user plans on re-installing Drupal.
         if ($environmentExists && $options['clone-content']) {
+            // Get (or re-fetch) a reference to our target multidev site.
+            $target = $site->getEnvironments()->get($multidev);
             $this->cloneContent($target, $env, $options['db-only']);
         }
 


### PR DESCRIPTION
I'm testing this PR in conjunction with the `source_env` argument on my personal site: https://github.com/stevector/stevector-composed/pull/144

I'm looking at a piece of content that was first edited in the Dev environment. Upon creation of the pull request I'm checking that the edit appears in the `pr-144` environment. And it does:
<img width="1149" alt="Screenshot 2025-03-13 at 11 07 33 AM" src="https://github.com/user-attachments/assets/a79d9fbd-0bf2-4322-8ada-350a83989565" />

And I'm editing the content again on the Dev environment (making the title of a node even longer):

<img width="1408" alt="Screenshot 2025-03-13 at 11 07 42 AM" src="https://github.com/user-attachments/assets/5ff94aec-8e88-498a-950a-d82d83414b3b" />

[I'm triggering another build on my personal site.](https://github.com/stevector/stevector-composed/pull/144/commits/65234b497ddf91098454f854e5594bc10090c584)


And I see in the build log that the `--clone-content` flag was included. 

<img width="548" alt="Screenshot 2025-03-13 at 11 18 26 AM" src="https://github.com/user-attachments/assets/9f9edf74-76b2-40db-8500-5d4b14eaa357" />

And then I'm again checking the `pr-144` environment to confirm that the content change has been replicated: 

<img width="1146" alt="Screenshot 2025-03-13 at 11 21 17 AM" src="https://github.com/user-attachments/assets/eb9a788e-ae11-42a4-9063-e2eaa93f958b" />

**Seeing this content change copied from one Pantheon environment to another confirms the behavior of `clone_content: true`**


And then to confirm the behavior of `clone_content: false` I made another content edit.

<img width="1512" alt="Screenshot 2025-03-13 at 11 23 42 AM" src="https://github.com/user-attachments/assets/25a3cb1d-6e02-4fd7-9fc8-6b6b08094f2a" />


[And then I changed `clone_content` to false.](https://github.com/stevector/stevector-composed/pull/144/commits/69117c9a0ddc4b0632d5d550a41aa4fae9f0912b)

<img width="599" alt="Screenshot 2025-03-13 at 11 27 27 AM" src="https://github.com/user-attachments/assets/4042aa5c-c9c1-4204-892d-b8b1dc2e52fd" />

And another build occurred which did not contain the `--clone-content` flag.

<img width="1256" alt="Screenshot 2025-03-13 at 11 28 27 AM" src="https://github.com/user-attachments/assets/61f0b893-7300-4a30-a812-36fd31d325ef" />

And after build completion, the `pr-144` did not contain the new content update.

<img width="1427" alt="Screenshot 2025-03-13 at 11 31 32 AM" src="https://github.com/user-attachments/assets/b2e0d1fb-d644-47f4-942e-b1d91be5fc90" />

